### PR TITLE
Updated default version to 3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hosts
 *.swp
+*.retry

--- a/play.yml
+++ b/play.yml
@@ -4,7 +4,7 @@
 - hosts: all
   remote_user: root
   vars:
-    mattermost_version: v1.1.0
+    mattermost_version: 3.2.0
 
    #The user the mattermost process will run as. The group will match.
     mattermost_user: mattermost

--- a/roles/mattermost/tasks/main.yml
+++ b/roles/mattermost/tasks/main.yml
@@ -1,12 +1,24 @@
 ---
-- name: download code from GitHub
+- name: add key for ppa python repository
+  apt_key: keyserver=keyserver.ubuntu.com id=DB82666C state=present
+
+- name: Add ppa python repository
+  apt_repository: repo='deb http://ppa.launchpad.net/fkrull/deadsnakes-python2.7/ubuntu {{ ansible_distribution_release }} main' state=present update_cache=yes
+
+- name: ensure python2.7 latest  is installed
+  apt:
+    pkg: python2.7
+    state: latest
+    install_recommends: no
+
+- name: download code from MatterMost website
   get_url: 
-    url: https://github.com/mattermost/platform/releases/download/{{ mattermost_version }}/mattermost.tar.gz
+    url: https://releases.mattermost.com/{{ mattermost_version }}/mattermost-team-{{ mattermost_version }}-linux-amd64.tar.gz
     dest: /tmp/
 
 - name: unpack mattermost archive
   unarchive: 
-    src: /tmp/mattermost.tar.gz 
+    src: /tmp/mattermost-team-{{ mattermost_version }}-linux-amd64.tar.gz 
     dest: /opt/
     copy: no
 


### PR DESCRIPTION
Various updates so that the playbook works ansible 2+ (mostly postgres stuff). Also installs a python ppa so that the version of python 2.x is newer than the version in the Ubuntu packages.  Updates the default installed version of Mattermost to 3.2.0. The Mattermost binary is now downloaded from Mattermost.com instead of GitHub - the binary is no longer available on GitHub, just the source code. 
