### PR TITLE
Use letsencrypt instead of snakeoil certs

### DIFF
--- a/play.yml
+++ b/play.yml
@@ -16,8 +16,13 @@
    #Choose a secure password. It is recommended you create a random password using 
    #an external utility.
     db_password: notReallyPassword
+
+   # This is the email address you want to be attached to the letsencrypt certificate. It should be valid.
+    cert_email_address: abc@123.com
+
   roles:
-     - common
-     - postgres
-     - mattermost
-     - nginx
+    - common
+    - postgres
+    - mattermost
+    - nginx
+    - cron

--- a/roles/cron/files/renew.sh
+++ b/roles/cron/files/renew.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm /etc/nginx/sites-enabled/mattermost
+ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+service nginx restart
+/opt/letsencrypt/letsencrypt-auto renew --quiet --no-self-upgrade
+rm /etc/nginx/sites-enabled/default
+ln -s /etc/nginx/sites-available/mattermost 
+/etc/nginx/sites-enabled/mattermost
+service nginx restart

--- a/roles/cron/tasks/main.yml
+++ b/roles/cron/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: create cron directory in /opt/
+  file:
+    path: /opt/cron
+    state: directory
+
+- name: Copy shell script to be used in cron job
+  copy:
+    src: renew.sh
+    dest: /opt/cron/renew.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Create cron job to automatically update SSL cert
+  cron:
+    name: "Renew letsencrypt SSL certs"
+    minute: "47"
+    hour: "23"
+    month: "*"
+    day: "15"
+    job: "/opt/cron/renew.sh"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,27 +1,40 @@
 ---
 - name: install nginx
-  apt:
-    name: nginx
+  apt: name={{item}}
+  with_items:
+    - nginx
+    - git  
 
 - name: apply nginx config template
   template:  
     src: mattermost.j2
     dest: /etc/nginx/sites-available/mattermost
 
-- name: remove nginx default site
-  file:
-    path: /etc/nginx/sites-enabled/default
-    state: absent
+- name: download letsencrypt
+  git: 
+    repo: https://github.com/letsencrypt/letsencrypt 
+    dest: /opt/letsencrypt/
+
+- name: Install letsencrypt dependencies (takes a while)
+  command: /opt/letsencrypt/letsencrypt-auto --help ## This is a bit stupid but it installs the deps without input.
 
 - name: Add SSL directory in /etc/nginx
   file:
     path: /etc/nginx/ssl
     state: directory
 
-- name: create self-signed SSL cert
-  command: openssl req -new -nodes -x509 -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN={{ ansible_fqdn }}" -days 3650 -keyout /etc/nginx/ssl/mattermost.key -out /etc/nginx/ssl/mattermost.crt -extensions v3_ca 
-  args:
-    creates: /etc/nginx/ssl/mattermost.crt
+- name: Create letsencrypt config file
+  template: 
+    src: LEconfig.j2
+    dest: /etc/nginx/ssl/cli.ini
+
+- name: Get cert from letsencrypt
+  command: /opt/letsencrypt/letsencrypt-auto certonly -c /etc/nginx/ssl/cli.ini --agree-tos
+
+- name: remove nginx default site
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
 
 - name: add mattermost site
   file:

--- a/roles/nginx/templates/LEconfig.j2
+++ b/roles/nginx/templates/LEconfig.j2
@@ -1,0 +1,9 @@
+rsa-key-size = 4096
+
+email = {{ cert_email_address }}
+
+domains = {{ ansible_fqdn }}
+
+authenticator = webroot
+webroot-path = /usr/share/nginx/html
+

--- a/roles/nginx/templates/mattermost.j2
+++ b/roles/nginx/templates/mattermost.j2
@@ -3,8 +3,8 @@ server {
         server_name {{ ansible_fqdn }};
 
         ssl on;
-        ssl_certificate /etc/nginx/ssl/mattermost.crt;
-        ssl_certificate_key /etc/nginx/ssl/mattermost.key;
+        ssl_certificate /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem;
+        ssl_certificate_key  /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem;
         ssl_session_timeout 5m;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";


### PR DESCRIPTION
SSL security is now automatic thanks to letsencrypt. The certs renew automatically but nginx has to be restarted for that to happen properly because there isn't a nginx plugin for letsencrypt that's out of beta. 
