### PR TITLE
update letsencrypt to use a given domain, also add non-interactive to…

### DIFF
--- a/play.yml
+++ b/play.yml
@@ -3,6 +3,7 @@
 # run "ansible-playbook play.yml -i hosts" from this directory
 - hosts: all
   remote_user: root
+  become: yes
   gather_facts: no
   pre_tasks:
     - name: Install python

--- a/play.yml
+++ b/play.yml
@@ -30,6 +30,9 @@
    # This is the email address you want to be attached to the letsencrypt certificate. It should be valid.
     cert_email_address: abc@123.com
 
+   # This is the domain name to be used for letsencrypt.  Be sure to point this at the host you're deploying to.
+    mattermost_fqdn: mm.mydomain.com
+
   roles:
     - postgres
     - mattermost

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -55,6 +55,6 @@
   when: (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6")
 
 - name: Get SSL certificate from letsencrypt
-  command: /opt/letsencrypt/letsencrypt-auto certonly -c /opt/letsencrypt/cli.ini --agree-tos 
+  command: /opt/letsencrypt/letsencrypt-auto certonly -d {{ mattermost_fqdn }} -c /opt/letsencrypt/cli.ini --agree-tos --non-interactive
   args:
-    creates: /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem
+    creates: /etc/letsencrypt/live/{{ mattermost_fqdn }}/fullchain.pem

--- a/roles/nginx/templates/mattermost.conf.j2
+++ b/roles/nginx/templates/mattermost.conf.j2
@@ -7,17 +7,17 @@ proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_
 # Redirect http to https
 server {
    listen 80 default_server;
-   server_name   {{ ansible_fqdn }};
+   server_name   {{ mattermost_fqdn }};
    return 301 https://$server_name$request_uri;
 }
 
 server {
    listen 443 ssl http2;
-   server_name    {{ ansible_fqdn }};
+   server_name    {{ mattermost_fqdn }};
 
    ssl on;
-   ssl_certificate /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem;
-   ssl_certificate_key /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem;
+   ssl_certificate /etc/letsencrypt/live/{{ mattermost_fqdn }}/fullchain.pem;
+   ssl_certificate_key /etc/letsencrypt/live/{{ mattermost_fqdn }}/privkey.pem;
    ssl_session_timeout 5m;
    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
    ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';


### PR DESCRIPTION
When deploying to an AWS instance, I needed to be able to specify the domain name for letsencrypt to use.  Otherwise, {{ ansible_hostname }} was defaulting to a domain name of the form "ec2-ip-address-with-dashes.us-east-2.compute.amazonaws.com".

I also had to add "--non-interactive" to the letsencrypt command line.

Also, I had to add "become: yes" to the play, since have to sudo up to root for most actions.  I'm not sure if this would be problematic if we're already logging in as root, so feel free to nuke that commit.